### PR TITLE
Fix interpolation

### DIFF
--- a/lib/operations.js
+++ b/lib/operations.js
@@ -143,7 +143,7 @@ function interpolateStopTimes (db, callback) {
               }
             } else {
               // sqlite uninterpolated shows up ass 'NULL'
-              if (!stopTime.arrival_time || stopTime.arrival_time === 'NULL') {
+              if (stopTime.arrival_time === null || stopTime.arrival_time === 'NULL') {
                 lastTimepoint = lastStopTime
                 lookingForNextTimepoint = true
               }

--- a/lib/operations.js
+++ b/lib/operations.js
@@ -85,14 +85,20 @@ function interpolateStopTimes (db, callback) {
 
   let rowTimeout
 
+  /**
+   * Helper function to account for stop_times that are completely interpolated
+   */
   function onRowComplete () {
     if (rowTimeout) {
       clearTimeout(rowTimeout)
     }
     if (isComplete && numUpdates === 0) {
       rowTimeout = setTimeout(() => {
-        console.log('interpolation completed successfully (no interpolations needed)')
-        callback()
+        // check yet again, because interpolated times could've appeared since setting timeout
+        if (numUpdates === 0) {
+          console.log('interpolation completed successfully (no interpolations needed)')
+          callback()
+        }
       }, 10000)
     }
   }


### PR DESCRIPTION
- If a stop time that should be interpolated is found after the row
timeout is initiated, a callback will be called twice.  Fix by checking
condition in timeout.
- account for departure_time of 0